### PR TITLE
path dispatch: match against relative path, start from the beginning

### DIFF
--- a/google_takeout_parser/path_dispatch.py
+++ b/google_takeout_parser/path_dispatch.py
@@ -198,10 +198,11 @@ class TakeoutParser:
         """
         Match one of the handler regexes to a function which parses the file
         """
+        assert not p.is_absolute(), p  # should be relative to Takeout dir
         sf = str(p)
         for prefix, h in handler.items():
             # regex match the map (e.g. above)
-            if bool(re.search(prefix, sf)):
+            if bool(re.match(prefix, sf)):
                 return h  # could be None, if chosen to ignore
         else:
             return RuntimeError(f"No function to handle parsing {sf}")
@@ -214,10 +215,11 @@ class TakeoutParser:
                 continue
             if not f.is_file():
                 continue
+            rf = f.relative_to(self.takeout_dir)
 
             # if user overrode some function, use that
             user_handler: HandlerMatch = self.__class__._match_handler(
-                f, self.additional_handlers
+                rf, self.additional_handlers
             )
             # user handler matched something
             if not isinstance(user_handler, Exception):
@@ -230,7 +232,7 @@ class TakeoutParser:
 
             # try the default matchers
             def_handler: HandlerMatch = self.__class__._match_handler(
-                f, DEFAULT_HANDLER_MAP
+                rf, DEFAULT_HANDLER_MAP
             )
             # default handler
             if not isinstance(def_handler, Exception):

--- a/tests/test_google_takeout.py
+++ b/tests/test_google_takeout.py
@@ -10,4 +10,4 @@ def test_structure() -> None:
     tk = TakeoutParser(recent_takeout)
     m = tk.dispatch_map()
     assert len(files) == 53
-    assert len(m) == 30
+    assert len(m) == 32


### PR DESCRIPTION
had to update the test, since previously it wasn't detecting:

- My Activity/Chrome/MyActivity.json due to Chrome in DEFAULT_HANDLER_MAP
- My Activity/Google Play Store/MyActivity.json due to Google Play Store in DEFAULT_HANDLER_MAP

Not sure if it's the best way to fix, but looks like clean enough