### PR TITLE
path dispatch: better support for objects that mimic Path

### DIFF
--- a/google_takeout_parser/path_dispatch.py
+++ b/google_takeout_parser/path_dispatch.py
@@ -173,7 +173,9 @@ class TakeoutParser:
             "raise": raise exceptions
             "drop": drop/ignore exceptions
         """
-        self.takeout_dir = Path(takeout_dir).absolute()
+        # isinstance check to avoid messing up objects which mimic Path (e.g. zip wrappers)
+        takeout_dir = takeout_dir if isinstance(takeout_dir, Path) else Path(takeout_dir)
+        self.takeout_dir = takeout_dir.absolute()
         if not self.takeout_dir.exists():
             raise FileNotFoundError(f"{self.takeout_dir} does not exist!")
         self.cachew_identifier: Optional[str] = cachew_identifier


### PR DESCRIPTION
discussed [on zulip](https://memex.zulipchat.com/#narrow/stream/279601-hpi/topic/my.2Ediscord.20.2F.20processing.20archived.20data/near/278750742), will add the `ZipPath` to HPI and will add tests against zip files to the HPI test suite