### PR TITLE
Parse PlaceVisits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 tags*
 *.pdf
 test.py
-
+*.sublime-workspace
+.DS_Store
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -108,6 +109,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+*.sublime-project
 
 # Spyder project settings
 .spyderproject

--- a/google_takeout_parser/models.py
+++ b/google_takeout_parser/models.py
@@ -105,13 +105,27 @@ class PlayStoreAppInstall(BaseEvent):
 class Location(BaseEvent):
     lng: float
     lat: float
+    address: Optional[str]
     accuracy: Optional[int]
     dt: datetime
+    placeId: Optional[str]
 
     @property
     def key(self) -> Tuple[float, float, Optional[int], int]:
         return (self.lng, self.lat, self.accuracy, int(self.dt.timestamp()))
 
+@dataclass
+class PlaceVisit(BaseEvent):
+    location: Location
+    lng: float
+    lat: float
+    startTime: datetime
+    endTime: datetime
+    visitConfidence: Optional[int]
+
+    @property
+    def key(self) -> Tuple[float, float, Optional[int]]:
+        return (self.lng, self.lat, self.visitConfidence)
 
 @dataclass
 class ChromeHistory(BaseEvent):

--- a/google_takeout_parser/parse_json.py
+++ b/google_takeout_parser/parse_json.py
@@ -137,8 +137,26 @@ def _parse_location_history(p: Path) -> Iterator[Res[Location]]:
         except Exception as e:
             yield e
 
-
 _parse_location_history.return_type = Location  # type: ignore[attr-defined]
+
+def _parse_semantic_location_history(p: Path) -> Iterator[Res[Location]]:
+    json_data = json.loads(p.read_text())
+    if "timelineObjects" not in json_data:
+        yield RuntimeError(f"Locations: no 'timelineObjects' key in '{p}'")
+    for place in json_data.get("placeVisit", []):
+        loc = place.get("location")
+        accuracy = location.get("accuracy")
+        try:
+            yield Location(
+                lng=float(loc["longitudeE7"]) / 1e7,
+                lat=float(loc["latitudeE7"]) / 1e7,
+                dt=_parse_location_timestamp(loc),
+                accuracy=None if accuracy is None else int(accuracy)
+            )
+        except Exception as e:
+            yield e
+
+_parse_semantic_location_history.return_type = Location  # type: ignore[attr-defined]
 
 
 def _parse_chrome_history(p: Path) -> Iterator[Res[ChromeHistory]]:

--- a/google_takeout_parser/path_dispatch.py
+++ b/google_takeout_parser/path_dispatch.py
@@ -35,6 +35,7 @@ from .parse_json import (
     _parse_app_installs,
     _parse_json_activity,
     _parse_location_history,
+    _parse_semantic_location_history,
     _parse_chrome_history,
 )
 
@@ -95,7 +96,7 @@ DEFAULT_HANDLER_MAP: HandlerMap = {
     r"Chrome": None,  # Ignore rest of Chrome stuff
     r"Google Play Store/Installs.json": _parse_app_installs,
     r"Google Play Store/": None,  # ignore anything else in Play Store
-    r"Location History/Semantic Location History/.*": None,  # not that much data here. maybe parse it?
+    r"Location History/Semantic Location History/.*?/.*.json": _parse_semantic_location_history,  
     # optional space to handle pre-2017 data
     r"Location History/Location( )?History.json": _parse_location_history,  # old path to Location History
     r"Location History/Records.json": _parse_location_history,  # new path to Location History

--- a/google_takeout_parser/path_dispatch.py
+++ b/google_takeout_parser/path_dispatch.py
@@ -96,7 +96,7 @@ DEFAULT_HANDLER_MAP: HandlerMap = {
     r"Chrome": None,  # Ignore rest of Chrome stuff
     r"Google Play Store/Installs.json": _parse_app_installs,
     r"Google Play Store/": None,  # ignore anything else in Play Store
-    r"Location History/Semantic Location History/.*?/.*.json": _parse_semantic_location_history,  
+    r"Location History/Semantic Location History/.*/.*.json": _parse_semantic_location_history,  
     # optional space to handle pre-2017 data
     r"Location History/Location( )?History.json": _parse_location_history,  # old path to Location History
     r"Location History/Records.json": _parse_location_history,  # new path to Location History


### PR DESCRIPTION
This PR adds the ability to parse basic ```PlaceVisit```s out of the Takeout Semantic Location History (which contains a person's Maps timeline / location history over time.) While the Semantic Location History JSON has ```timelineObjects``` as the root list, this PR does not attempt to add parsing these out, as this would require also parsing out ```ActivitySegments```. As such, this does not fully address Issue #16. A future PR could amend and add to this approach to do so.