### PR TITLE
semantic locaion history parser: handle missing placeId and placeConfidence

### DIFF
--- a/google_takeout_parser/models.py
+++ b/google_takeout_parser/models.py
@@ -169,7 +169,7 @@ class PlaceVisit(BaseEvent):
     sourceInfoDeviceTag: Optional[int]
     otherCandidateLocationsJSON: str
     # TODO: parse these into an enum of some kind? may be prone to breaking due to new values from google though...
-    placeConfidence: str
+    placeConfidence: Optional[str]  # older semantic history (pre-2018 didn't have it)
     placeVisitType: Optional[str]
     visitConfidence: float
     editConfirmationStatus: str

--- a/google_takeout_parser/parse_json.py
+++ b/google_takeout_parser/parse_json.py
@@ -168,7 +168,11 @@ def _parse_semantic_location_history(p: Path) -> Iterator[Res[PlaceVisit]]:
             yield RuntimeError(f"PlaceVisit: no '{missing_key}' key in '{p}'")
             continue
         try:
-            location = CandidateLocation.from_dict(placeVisit["location"])
+            location_json = placeVisit["location"]
+            if "placeId" not in location_json:
+                # even recent (as of 2023) places might miss it
+                continue
+            location = CandidateLocation.from_dict(location_json)
             duration = placeVisit["duration"]
             yield PlaceVisit(
                 name=location.name,
@@ -178,7 +182,7 @@ def _parse_semantic_location_history(p: Path) -> Iterator[Res[PlaceVisit]]:
                     placeVisit.get("otherCandidateLocations", []), separators=(",", ":")
                 ),
                 sourceInfoDeviceTag=location.sourceInfoDeviceTag,
-                placeConfidence=placeVisit["placeConfidence"],
+                placeConfidence=placeVisit.get("placeConfidence"),
                 placeVisitImportance=placeVisit.get("placeVisitImportance"),
                 placeVisitType=placeVisit.get("placeVisitType"),
                 visitConfidence=placeVisit["visitConfidence"],


### PR DESCRIPTION
- placeId may be missing for even recent places, I think that happens when google can't guess it
- placeConfidence seems to be missing historically, probably makes sense to make it optional?