### PR TITLE
parse_html.activity: about 30% speedup for html parsing

### DIFF
--- a/google_takeout_parser/__main__.py
+++ b/google_takeout_parser/__main__.py
@@ -88,7 +88,7 @@ def _serialize_default(obj: Any) -> Any:
     if isinstance(obj, Exception):
         return {"type": type(obj).__name__, "value": str(obj)}
     elif dataclasses.is_dataclass(obj):
-        d = dataclasses.asdict(obj)
+        d = dataclasses.asdict(obj)  # type: ignore[call-overload]  # see https://github.com/python/mypy/issues/17550
         assert "type" not in d
         d["type"] = type(obj).__name__
         return d


### PR DESCRIPTION
I've been reviewing some older takeouts, so had cachew off and parsing was a bit painful... so had a quick look in a profiler and did some optimization

A few optimizations
- using `.find` instead of `.select` is faster since it's not using CSS selectors
- using `SoupStrainer` is faster since it only does partial parsing and avoids materializing parts of soup we don't actually use

Measurements on a big `Chrome/MyActivity.html` file

- before
  - parsing (up to for loop over `outer_divs`: 17s
  - processing (everything in for loop): 16s

- after
  - parsing: 13s
  - procesing: 11s