### PR TITLE
parse_json._parse_location_history: speedup parsing about 50%

### DIFF
--- a/google_takeout_parser/time_utils.py
+++ b/google_takeout_parser/time_utils.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Union
 from datetime import datetime, timezone
 
@@ -10,11 +11,17 @@ def parse_datetime_millis(d: Union[str, float, int]) -> datetime:
     return parse_datetime_sec(int(d) / 1000)
 
 
-def parse_json_utc_date(ds: str) -> datetime:
-    utc_naive = datetime.fromisoformat(ds.rstrip("Z"))
-    return utc_naive.replace(tzinfo=timezone.utc)
+if sys.version_info[:2] >= (3, 11):
+    # from 3.11, it supports parsing strings ending with Z
+    parse_json_utc_date = datetime.fromisoformat
+else:
+    def parse_json_utc_date(ds: str) -> datetime:
+        utc_naive = datetime.fromisoformat(ds.rstrip("Z"))
+        return utc_naive.replace(tzinfo=timezone.utc)
 
 
 def test_parse_utc_date() -> None:
     expected = datetime(2021, 9, 30, 1, 44, 33, tzinfo=timezone.utc)
     assert parse_json_utc_date("2021-09-30T01:44:33.000Z") == expected
+
+    assert parse_json_utc_date("2023-01-27T22:46:47.389352Z") == datetime(2023, 1, 27, 22, 46, 47, 389352, tzinfo=timezone.utc)

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,8 @@ console_scripts =
     google_takeout_parser = google_takeout_parser.__main__:main
 
 [options.extras_require]
+optional =
+    orjson
 testing =
     flake8
     mypy


### PR DESCRIPTION
- use orjson if it's available with fallback to builtin json
- use builtin fromisoformat from python 3.11, it's much faster (and simpler!)

- before:
  - parsing json 9.6s
  - processing data: 7.0s
- after
  - parsing json: 5.7s
  - processing data: 3.1s