### PR TITLE
path dispatch: support both "Location History" and "Location History (Timeline)" directories

### DIFF
--- a/google_takeout_parser/locales/de.py
+++ b/google_takeout_parser/locales/de.py
@@ -16,9 +16,11 @@ HANDLER_MAP: HandlerMap = {
     r"Chrome": None,  # Ignore rest of Chrome stuff
     r"Google Play Store/Installs.json": _parse_app_installs,
     r"Google Play Store/": None,  # ignore anything else in Play Store
-    r"Location History \(Timeline\)/Semantic Location History/.*/.*.json": _parse_semantic_location_history,
-    r"Location History \(Timeline\)/Records.json": _parse_location_history,
-    r"Location History \(Timeline\)/": None,  # ignore anything else in Location History
+    # optional space to handle pre-2017 data
+    r"Location History/Location( )?History.json": _parse_location_history,  # old path to Location History
+    r"Location History( \(Timeline\))?/Records.json": _parse_location_history,
+    r"Location History( \(Timeline\))?/Semantic Location History/.*/.*.json": _parse_semantic_location_history,
+    r"Location History( \(Timeline\))?/": None,  # ignore anything else in Location History
     # Youtube
     r"YouTube( und YouTube Music)?/Verlauf/.*?.html": _parse_html_activity,
     r"YouTube( und YouTube Music)?/Verlauf/.*?.json": _parse_json_activity,

--- a/google_takeout_parser/locales/en.py
+++ b/google_takeout_parser/locales/en.py
@@ -45,12 +45,11 @@ HANDLER_MAP: HandlerMap = {
     r"Chrome": None,  # Ignore rest of Chrome stuff
     r"Google Play Store/Installs.json": _parse_app_installs,
     r"Google Play Store/": None,  # ignore anything else in Play Store
-    r"Location History/Semantic Location History/.*/.*.json": _parse_semantic_location_history,
     # optional space to handle pre-2017 data
     r"Location History/Location( )?History.json": _parse_location_history,  # old path to Location History
-    r"Location History/Records.json": _parse_location_history,  # new path to Location History
-    r"Location History/Settings.json": None,
-    r"Location History \(Timeline\)/Settings.json": None,
+    r"Location History( \(Timeline\))?/Records.json": _parse_location_history,
+    r"Location History( \(Timeline\))?/Semantic Location History/.*/.*.json": _parse_semantic_location_history,
+    r"Location History( \(Timeline\))?/": None,  # ignore anything else in Location History
     # HTML/JSON activity-like files which aren't in 'My Activity'
     # optional " and Youtube Music" to handle pre-2017 data
     r"YouTube( and YouTube Music)?/history/.*?.html": _parse_html_activity,

--- a/tests/test_locale_paths.py
+++ b/tests/test_locale_paths.py
@@ -13,7 +13,7 @@ def test_locale_paths() -> None:
     assert jpths == [
         "Chrome",
         "Location History",
-        r"Location History \(Timeline\)",  # using "Location History \\(Timeline\\)" fails on windows.
+        r"Location History( \(Timeline\))?",  # using "Location History \\(Timeline\\)" fails on windows.
         "Meine Aktivitäten",
         "My Activity",
         "YouTube( and YouTube Music)?",


### PR DESCRIPTION
in my case, locations were present in

- `Takeout/Location History/Location History.json` (since at least 2018)
- `Takeout/Location History/Records.json` (circa Apr 2022)
- `Takeout/Location History (Timeline)/Records.json` (circa Feb 2024)
- "Semantic Location History" appeared around Jan 2020 and also present under both paths

partially addresses https://github.com/seanbreckenridge/google_takeout_parser/issues/69