### PR TITLE
Add missing type annotations for bs4 and pytz in testing environment

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,8 @@ testing =
     flake8
     mypy
     pytest
+    types-beautifulsoup4
+    types-pytz
 
 [options.package_data]
 google_takeout_parser = py.typed


### PR DESCRIPTION
Quick fix for issues with the missing type issues raised by `mypy` as mentioned in #74 