### PR TITLE
Add additional fields to existing models

### DIFF
--- a/google_takeout_parser/locales/en.py
+++ b/google_takeout_parser/locales/en.py
@@ -42,7 +42,7 @@ from .common import (
 #
 HANDLER_MAP: HandlerMap = {
     r"Chrome/BrowserHistory.json": _parse_chrome_history,
-    r"Chrome/History.json": _parse_chrome_history, # Seems to have been renamed from BrowserHistory.json to History.json sometime between Oct 2023 to Sep 2024
+    r"Chrome/History.json": _parse_chrome_history,  # Seems to have been renamed from BrowserHistory.json to History.json sometime between Oct 2023 to Sep 2024
     r"Chrome": None,  # Ignore rest of Chrome stuff
     r"Google Play Store/Installs.json": _parse_app_installs,
     r"Google Play Store/": None,  # ignore anything else in Play Store

--- a/google_takeout_parser/locales/en.py
+++ b/google_takeout_parser/locales/en.py
@@ -42,6 +42,7 @@ from .common import (
 #
 HANDLER_MAP: HandlerMap = {
     r"Chrome/BrowserHistory.json": _parse_chrome_history,
+    r"Chrome/History.json": _parse_chrome_history, # Seems to have been renamed from BrowserHistory.json to History.json sometime between Oct 2023 to Sep 2024
     r"Chrome": None,  # Ignore rest of Chrome stuff
     r"Google Play Store/Installs.json": _parse_app_installs,
     r"Google Play Store/": None,  # ignore anything else in Play Store

--- a/google_takeout_parser/models.py
+++ b/google_takeout_parser/models.py
@@ -168,7 +168,10 @@ class LikedYoutubeVideo(BaseEvent):
 class PlayStoreAppInstall(BaseEvent):
     title: str
     dt: datetime
+    first_installation_dt: datetime
     device_name: Optional[str]
+    device_carrier: Optional[str]
+    device_manufacturer: Optional[str]
 
     @property
     def key(self) -> int:

--- a/google_takeout_parser/models.py
+++ b/google_takeout_parser/models.py
@@ -168,10 +168,10 @@ class LikedYoutubeVideo(BaseEvent):
 class PlayStoreAppInstall(BaseEvent):
     title: str
     dt: datetime
-    first_installation_dt: datetime
-    device_name: Optional[str]
-    device_carrier: Optional[str]
-    device_manufacturer: Optional[str]
+    firstInstallationDt: datetime
+    deviceName: Optional[str]
+    deviceCarrier: Optional[str]
+    deviceManufacturer: Optional[str]
 
     @property
     def key(self) -> int:
@@ -183,7 +183,7 @@ class Location(BaseEvent):
     lat: float
     lng: float
     accuracy: Optional[float]
-    device_tag: Optional[int]
+    deviceTag: Optional[int]
     source: Optional[str]
     dt: datetime
 

--- a/google_takeout_parser/models.py
+++ b/google_takeout_parser/models.py
@@ -167,18 +167,18 @@ class LikedYoutubeVideo(BaseEvent):
 @dataclass
 class PlayStoreAppInstall(BaseEvent):
     title: str
-    lastUpdateTime: datetime # timestamp for when the installation event occurred
-    firstInstallationTime: datetime # timetamp for when you first installed the app on the given device
+    lastUpdateTime: datetime  # timestamp for when the installation event occurred
+    firstInstallationTime: datetime  # timetamp for when you first installed the app on the given device
     deviceName: Optional[str]
     deviceCarrier: Optional[str]
     deviceManufacturer: Optional[str]
-    
+
     # noticed that lastUpdateTime was more accurate timestamp for the dt field
     # since different installation events of the same app had pretty close firstInstallation times
     # but the lastUpdate time was always at a later timestamp so I assumed it was the installation event
     @property
     def dt(self) -> datetime:
-        return self.lastUpdateTime # previously returned the firstInstallationTime
+        return self.lastUpdateTime  # previously returned the firstInstallationTime
 
     @property
     def key(self) -> int:

--- a/google_takeout_parser/models.py
+++ b/google_takeout_parser/models.py
@@ -167,15 +167,22 @@ class LikedYoutubeVideo(BaseEvent):
 @dataclass
 class PlayStoreAppInstall(BaseEvent):
     title: str
-    dt: datetime
-    firstInstallationDt: datetime
+    lastUpdateTime: datetime # timestamp for when the installation event occurred
+    firstInstallationTime: datetime # timetamp for when you first installed the app on the given device
     deviceName: Optional[str]
     deviceCarrier: Optional[str]
     deviceManufacturer: Optional[str]
+    
+    # noticed that lastUpdateTime was more accurate timestamp for the dt field
+    # since different installation events of the same app had pretty close firstInstallation times
+    # but the lastUpdate time was always at a later timestamp so I assumed it was the installation event
+    @property
+    def dt(self) -> datetime:
+        return self.lastUpdateTime # previously returned the firstInstallationTime
 
     @property
     def key(self) -> int:
-        return int(self.dt.timestamp())
+        return int(self.lastUpdateTime.timestamp())
 
 
 @dataclass

--- a/google_takeout_parser/models.py
+++ b/google_takeout_parser/models.py
@@ -269,6 +269,7 @@ class ChromeHistory(BaseEvent):
     title: str
     url: Url
     dt: datetime
+    pageTransition: Optional[str]
 
     @property
     def key(self) -> Tuple[str, int]:

--- a/google_takeout_parser/models.py
+++ b/google_takeout_parser/models.py
@@ -183,6 +183,8 @@ class Location(BaseEvent):
     lat: float
     lng: float
     accuracy: Optional[float]
+    device_tag: Optional[int]
+    source: Optional[str]
     dt: datetime
 
     @property

--- a/google_takeout_parser/parse_json.py
+++ b/google_takeout_parser/parse_json.py
@@ -81,7 +81,7 @@ def _parse_json_activity(p: Path) -> Iterator[Res[Activity]]:
                 time=parse_json_utc_date(time_str),
                 subtitles=subtitles,
                 details=[
-                    d.get("name", "")
+                    d["name"]
                     for d in blob.get("details", [])
                     if isinstance(d, dict) and "name" in d
                 ],
@@ -201,7 +201,7 @@ def _parse_semantic_location_history(p: Path) -> Iterator[Res[PlaceVisit]]:
             yield RuntimeError(f"PlaceVisit: no '{missing_key}' key in '{p}'")
             continue
         try:
-            location_json = placeVisit.get("location")
+            location_json = placeVisit["location"]
             missing_location_key = _check_required_keys(
                 location_json, _sem_required_location_keys
             )
@@ -259,7 +259,7 @@ def _parse_chrome_history(p: Path) -> Iterator[Res[ChromeHistory]]:
         yield RuntimeError(f"Chrome/BrowserHistory: no 'Browser History' key in '{p}'")
     for item in json_data.get("Browser History", []):
         try:
-            time_naive = datetime.utcfromtimestamp(item.get("time_usec") / 10**6)
+            time_naive = datetime.utcfromtimestamp(item["time_usec"] / 10**6)
             yield ChromeHistory(
                 title=item["title"],
                 # dont convert to https here, this is just the users history

--- a/google_takeout_parser/parse_json.py
+++ b/google_takeout_parser/parse_json.py
@@ -192,10 +192,10 @@ def _parse_semantic_location_history(p: Path) -> Iterator[Res[PlaceVisit]]:
         yield RuntimeError(f"Locations: no 'timelineObjects' key in '{p}'")
     timelineObjects = json_data.get("timelineObjects", [])
     for timelineObject in timelineObjects:
-        placeVisit = timelineObject.get("placeVisit")
-        if placeVisit is None:
+        if "placeVisit" not in timelineObject:
             yield RuntimeError(f"PlaceVisit: no 'placeVisit' key in '{p}'")
             continue
+        placeVisit = timelineObject["placeVisit"]
         missing_key = _check_required_keys(placeVisit, _sem_required_keys)
         if missing_key is not None:
             yield RuntimeError(f"PlaceVisit: no '{missing_key}' key in '{p}'")

--- a/google_takeout_parser/parse_json.py
+++ b/google_takeout_parser/parse_json.py
@@ -193,7 +193,7 @@ def _parse_semantic_location_history(p: Path) -> Iterator[Res[PlaceVisit]]:
     timelineObjects = json_data.get("timelineObjects", [])
     for timelineObject in timelineObjects:
         if "placeVisit" not in timelineObject:
-            yield RuntimeError(f"PlaceVisit: no 'placeVisit' key in '{p}'")
+            # yield RuntimeError(f"PlaceVisit: no 'placeVisit' key in '{p}'")
             continue
         placeVisit = timelineObject["placeVisit"]
         missing_key = _check_required_keys(placeVisit, _sem_required_keys)

--- a/google_takeout_parser/parse_json.py
+++ b/google_takeout_parser/parse_json.py
@@ -127,7 +127,10 @@ def _parse_app_installs(p: Path) -> Iterator[Res[PlayStoreAppInstall]]:
             yield PlayStoreAppInstall(
                 title=japp["install"]["doc"]["title"],
                 device_name=japp["install"]["deviceAttribute"].get("deviceDisplayName"),
-                dt=parse_json_utc_date(japp["install"]["firstInstallationTime"]),
+                device_carrier=japp["install"]["deviceAttribute"]["carrier"],
+                device_manufacturer=japp["install"]["deviceAttribute"]["manufacturer"],
+                dt=parse_json_utc_date(japp["install"]["lastUpdateTime"]),
+                first_installation_dt=parse_json_utc_date(japp['install']['firstInstallationTime']),
             )
         except Exception as e:
             yield e

--- a/google_takeout_parser/parse_json.py
+++ b/google_takeout_parser/parse_json.py
@@ -129,8 +129,8 @@ def _parse_app_installs(p: Path) -> Iterator[Res[PlayStoreAppInstall]]:
                 deviceName=japp["install"]["deviceAttribute"].get("deviceDisplayName"),
                 deviceCarrier=japp["install"]["deviceAttribute"]["carrier"],
                 deviceManufacturer=japp["install"]["deviceAttribute"]["manufacturer"],
-                dt=parse_json_utc_date(japp["install"]["lastUpdateTime"]),
-                firstInstallationDt=parse_json_utc_date(japp['install']['firstInstallationTime']),
+                lastUpdateTime=parse_json_utc_date(japp["install"]["lastUpdateTime"]),
+                firstInstallationTime=parse_json_utc_date(japp['install']['firstInstallationTime']),
             )
         except Exception as e:
             yield e

--- a/google_takeout_parser/parse_json.py
+++ b/google_takeout_parser/parse_json.py
@@ -266,6 +266,7 @@ def _parse_chrome_history(p: Path) -> Iterator[Res[ChromeHistory]]:
                 # and there's likely lots of items that aren't https
                 url=item["url"],
                 dt=time_naive.replace(tzinfo=timezone.utc),
+                pageTransition=item["page_transition"] if "page_transition" in item else None
             )
         except Exception as e:
             yield e

--- a/google_takeout_parser/parse_json.py
+++ b/google_takeout_parser/parse_json.py
@@ -126,11 +126,11 @@ def _parse_app_installs(p: Path) -> Iterator[Res[PlayStoreAppInstall]]:
         try:
             yield PlayStoreAppInstall(
                 title=japp["install"]["doc"]["title"],
-                device_name=japp["install"]["deviceAttribute"].get("deviceDisplayName"),
-                device_carrier=japp["install"]["deviceAttribute"]["carrier"],
-                device_manufacturer=japp["install"]["deviceAttribute"]["manufacturer"],
+                deviceName=japp["install"]["deviceAttribute"].get("deviceDisplayName"),
+                deviceCarrier=japp["install"]["deviceAttribute"]["carrier"],
+                deviceManufacturer=japp["install"]["deviceAttribute"]["manufacturer"],
                 dt=parse_json_utc_date(japp["install"]["lastUpdateTime"]),
-                first_installation_dt=parse_json_utc_date(japp['install']['firstInstallationTime']),
+                firstInstallationDt=parse_json_utc_date(japp['install']['firstInstallationTime']),
             )
         except Exception as e:
             yield e
@@ -152,7 +152,7 @@ def _parse_location_history(p: Path) -> Iterator[Res[Location]]:
         yield RuntimeError(f"Locations: no 'locations' key in '{p}'")
     for loc in json_data.get("locations", []):
         accuracy = loc.get("accuracy")
-        device_tag = loc.get("deviceTag")
+        deviceTag = loc.get("deviceTag")
         source = loc.get("source")
         try:
             yield Location(
@@ -160,7 +160,7 @@ def _parse_location_history(p: Path) -> Iterator[Res[Location]]:
                 lat=float(loc["latitudeE7"]) / 1e7,
                 dt=_parse_timestamp_key(loc, "timestamp"),
                 accuracy=None if accuracy is None else float(accuracy),
-                device_tag=None if device_tag is None else device_tag,
+                deviceTag=None if deviceTag is None else deviceTag,
                 source=None if source is None else str(source)
             )
         except Exception as e:

--- a/google_takeout_parser/parse_json.py
+++ b/google_takeout_parser/parse_json.py
@@ -152,12 +152,16 @@ def _parse_location_history(p: Path) -> Iterator[Res[Location]]:
         yield RuntimeError(f"Locations: no 'locations' key in '{p}'")
     for loc in json_data.get("locations", []):
         accuracy = loc.get("accuracy")
+        device_tag = loc.get("deviceTag")
+        source = loc.get("source")
         try:
             yield Location(
                 lng=float(loc["longitudeE7"]) / 1e7,
                 lat=float(loc["latitudeE7"]) / 1e7,
                 dt=_parse_timestamp_key(loc, "timestamp"),
                 accuracy=None if accuracy is None else float(accuracy),
+                device_tag=None if device_tag is None else device_tag,
+                source=None if source is None else str(source)
             )
         except Exception as e:
             yield e

--- a/google_takeout_parser/parse_json.py
+++ b/google_takeout_parser/parse_json.py
@@ -54,34 +54,34 @@ def _parse_json_activity(p: Path) -> Iterator[Res[Activity]]:
                 # sometimes it's just empty ("My Activity/Assistant" data circa 2018)
                 if "name" not in s:
                     continue
-                subtitles.append(Subtitles(name=s["name"], url=s.get("url")))
+                subtitles.append(Subtitles(name=str(s.get("name")), url=s.get("url")))
 
             # till at least 2017
             old_format = "snippet" in blob
             if old_format:
-                blob = blob["snippet"]
+                blob = blob.get("snippet")
                 header = "YouTube"  # didn't have header
-                time_str = blob["publishedAt"]
+                time_str = blob.get("publishedAt")
             else:
                 _header = blob.get("header")
                 if _header is None:
                     # some pre-2021 MyActivity/Chrome/MyActivty.json contain a few items without header
                     # they always seem to be originating from viewing page source
-                    if blob["title"].startswith("Visited view-source:"):
+                    if blob.get("title").startswith("Visited view-source:"):
                         _header = "Chrome"
                 assert _header is not None, blob
                 header = _header
-                time_str = blob["time"]
+                time_str = blob.get("time")
 
             yield Activity(
                 header=header,
-                title=blob["title"],
+                title=blob.get("title"),
                 titleUrl=convert_to_https_opt(blob.get("titleUrl")),
                 description=blob.get("description"),
                 time=parse_json_utc_date(time_str),
                 subtitles=subtitles,
                 details=[
-                    d["name"]
+                    str(d.get("name"))
                     for d in blob.get("details", [])
                     if isinstance(d, dict) and "name" in d
                 ],
@@ -107,12 +107,12 @@ def _parse_likes(p: Path) -> Iterator[Res[LikedYoutubeVideo]]:
     for jlike in json_data:
         try:
             yield LikedYoutubeVideo(
-                title=jlike["snippet"]["title"],
-                desc=jlike["snippet"]["description"],
+                title=jlike.get("snippet", {}).get("title"),
+                desc=jlike.get("snippet", {}).get("description"),
                 link="https://youtube.com/watch?v={}".format(
-                    jlike["contentDetails"]["videoId"]
+                    jlike.get("contentDetails", {}).get("videoId")
                 ),
-                dt=parse_json_utc_date(jlike["snippet"]["publishedAt"]),
+                dt=parse_json_utc_date(jlike.get("snippet", {}).get("publishedAt")),
             )
         except Exception as e:
             yield e
@@ -125,12 +125,12 @@ def _parse_app_installs(p: Path) -> Iterator[Res[PlayStoreAppInstall]]:
     for japp in json_data:
         try:
             yield PlayStoreAppInstall(
-                title=japp["install"]["doc"]["title"],
-                deviceName=japp["install"]["deviceAttribute"].get("deviceDisplayName"),
-                deviceCarrier=japp["install"]["deviceAttribute"]["carrier"],
-                deviceManufacturer=japp["install"]["deviceAttribute"]["manufacturer"],
-                lastUpdateTime=parse_json_utc_date(japp["install"]["lastUpdateTime"]),
-                firstInstallationTime=parse_json_utc_date(japp['install']['firstInstallationTime']),
+                title=japp.get("install", {}).get("doc", {}).get("title"),
+                deviceName=japp.get("install", {}).get("deviceAttribute", {}).get("deviceDisplayName"),
+                deviceCarrier=japp.get("install", {}).get("deviceAttribute", {}).get("carrier"),
+                deviceManufacturer=japp.get("install", {}).get("deviceAttribute", {}).get("manufacturer"),
+                lastUpdateTime=parse_json_utc_date(japp.get("install", {}).get("lastUpdateTime")),
+                firstInstallationTime=parse_json_utc_date(japp.get('install', {}).get('firstInstallationTime')),
             )
         except Exception as e:
             yield e
@@ -156,8 +156,8 @@ def _parse_location_history(p: Path) -> Iterator[Res[Location]]:
         source = loc.get("source")
         try:
             yield Location(
-                lng=float(loc["longitudeE7"]) / 1e7,
-                lat=float(loc["latitudeE7"]) / 1e7,
+                lng=float(loc.get("longitudeE7")) / 1e7,
+                lat=float(loc.get("latitudeE7")) / 1e7,
                 dt=_parse_timestamp_key(loc, "timestamp"),
                 accuracy=None if accuracy is None else float(accuracy),
                 deviceTag=None if deviceTag is None else int(deviceTag),
@@ -195,13 +195,13 @@ def _parse_semantic_location_history(p: Path) -> Iterator[Res[PlaceVisit]]:
         if "placeVisit" not in timelineObject:
             # yield RuntimeError(f"PlaceVisit: no 'placeVisit' key in '{p}'")
             continue
-        placeVisit = timelineObject["placeVisit"]
+        placeVisit = timelineObject.get("placeVisit")
         missing_key = _check_required_keys(placeVisit, _sem_required_keys)
         if missing_key is not None:
             yield RuntimeError(f"PlaceVisit: no '{missing_key}' key in '{p}'")
             continue
         try:
-            location_json = placeVisit["location"]
+            location_json = placeVisit.get("location")
             missing_location_key = _check_required_keys(
                 location_json, _sem_required_location_keys
             )
@@ -214,7 +214,7 @@ def _parse_semantic_location_history(p: Path) -> Iterator[Res[PlaceVisit]]:
             location = CandidateLocation.from_dict(location_json)
             placeId = location.placeId
             assert placeId is not None, location_json  # this is always present for the actual location
-            duration = placeVisit["duration"]
+            duration = placeVisit.get("duration")
             yield PlaceVisit(
                 name=location.name,
                 address=location.address,
@@ -233,12 +233,12 @@ def _parse_semantic_location_history(p: Path) -> Iterator[Res[PlaceVisit]]:
                 lng=location.lng,
                 lat=location.lat,
                 centerLat=(
-                    float(placeVisit["centerLatE7"]) / 1e7
+                    float(placeVisit.get("centerLatE7")) / 1e7
                     if "centerLatE7" in placeVisit
                     else None
                 ),
                 centerLng=(
-                    float(placeVisit["centerLngE7"]) / 1e7
+                    float(placeVisit.get("centerLngE7")) / 1e7
                     if "centerLngE7" in placeVisit
                     else None
                 ),
@@ -259,14 +259,14 @@ def _parse_chrome_history(p: Path) -> Iterator[Res[ChromeHistory]]:
         yield RuntimeError(f"Chrome/BrowserHistory: no 'Browser History' key in '{p}'")
     for item in json_data.get("Browser History", []):
         try:
-            time_naive = datetime.utcfromtimestamp(item["time_usec"] / 10**6)
+            time_naive = datetime.utcfromtimestamp(item.get("time_usec") / 10**6)
             yield ChromeHistory(
-                title=item["title"],
+                title=item.get("title"),
                 # dont convert to https here, this is just the users history
                 # and there's likely lots of items that aren't https
-                url=item["url"],
+                url=item.get("url"),
                 dt=time_naive.replace(tzinfo=timezone.utc),
-                pageTransition=item["page_transition"] if "page_transition" in item else None
+                pageTransition=item.get("page_transition") if "page_transition" in item else None
             )
         except Exception as e:
             yield e

--- a/google_takeout_parser/parse_json.py
+++ b/google_takeout_parser/parse_json.py
@@ -160,8 +160,8 @@ def _parse_location_history(p: Path) -> Iterator[Res[Location]]:
                 lat=float(loc["latitudeE7"]) / 1e7,
                 dt=_parse_timestamp_key(loc, "timestamp"),
                 accuracy=None if accuracy is None else float(accuracy),
-                deviceTag=None if deviceTag is None else deviceTag,
-                source=None if source is None else str(source)
+                deviceTag=None if deviceTag is None else int(deviceTag),
+                source=None if source is None else source
             )
         except Exception as e:
             yield e

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,8 @@ testing =
     flake8
     mypy
     pytest
+    types-beautifulsoup4
+    types-pytz
 
 [options.package_data]
 google_takeout_parser = py.typed

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -89,10 +89,10 @@ def test_parse_app_installs(tmp_path_f: Path) -> None:
     assert res == [
         models.PlayStoreAppInstall(
             title="ClickUp - Manage Teams \u0026 Tasks",
-            dt=datetime.datetime(
+            lastUpdateTime=datetime.datetime(
                 2024, 8, 27, 22, 55, 15, 184610, tzinfo=datetime.timezone.utc
             ),
-            firstInstallationDt=datetime.datetime(
+            firstInstallationTime=datetime.datetime(
                 2022, 3, 14, 7, 6, 12, 70725, tzinfo=datetime.timezone.utc
             ),
             deviceName="samsung SM-S901E",

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -92,12 +92,12 @@ def test_parse_app_installs(tmp_path_f: Path) -> None:
             dt=datetime.datetime(
                 2024, 8, 27, 22, 55, 15, 184610, tzinfo=datetime.timezone.utc
             ),
-            first_installation_dt=datetime.datetime(
+            firstInstallationDt=datetime.datetime(
                 2022, 3, 14, 7, 6, 12, 70725, tzinfo=datetime.timezone.utc
             ),
-            device_name="samsung SM-S901E",
-            device_carrier="Vodafone",
-            device_manufacturer="samsung",
+            deviceName="samsung SM-S901E",
+            deviceCarrier="Vodafone",
+            deviceManufacturer="samsung",
         )
     ]
 
@@ -115,7 +115,7 @@ def test_location_old(tmp_path_f: Path) -> None:
                 2017, 12, 10, 23, 14, 58, tzinfo=datetime.timezone.utc
             ),
             accuracy=10.0,
-            device_tag=None,
+            deviceTag=None,
             source=None,
         ),
     ]
@@ -134,7 +134,7 @@ def test_location_new(tmp_path_f: Path) -> None:
                 2017, 12, 10, 23, 14, 58, 30000, tzinfo=datetime.timezone.utc
             ),
             accuracy=10.0,
-            device_tag=-80241446968629135069,
+            deviceTag=-80241446968629135069,
             source=None,
         ),
     ]
@@ -152,7 +152,7 @@ def test_location_2024(tmp_path_f: Path) -> None:
                 2014, 7, 18, 14, 59, 59, 914000, tzinfo=datetime.timezone.utc
             ),
             accuracy=10.0,
-            device_tag=1978796627,
+            deviceTag=1978796627,
             source="WIFI",
         ),
     ]

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -115,6 +115,8 @@ def test_location_old(tmp_path_f: Path) -> None:
                 2017, 12, 10, 23, 14, 58, tzinfo=datetime.timezone.utc
             ),
             accuracy=10.0,
+            device_tag=None,
+            source=None,
         ),
     ]
 
@@ -132,6 +134,26 @@ def test_location_new(tmp_path_f: Path) -> None:
                 2017, 12, 10, 23, 14, 58, 30000, tzinfo=datetime.timezone.utc
             ),
             accuracy=10.0,
+            device_tag=-80241446968629135069,
+            source=None,
+        ),
+    ]
+    
+def test_location_2024(tmp_path_f: Path) -> None:
+    contents = '{"locations":[{"latitudeE7":351324213,"longitudeE7":-1122434441,"accuracy":10,"activity":[{"activity":[{"type":"UNKNOWN","confidence":65},{"type":"IN_VEHICLE","confidence":27},{"type":"STILL","confidence":6},{"type":"ON_BICYCLE","confidence":2}],"timestamp":"2014-07-18T15:00:04.403Z"}],"source":"WIFI","deviceTag":1978796627,"timestamp":"2014-07-18T14:59:59.914Z"}]}'
+    fp = tmp_path_f / "file"
+    fp.write_text(contents)
+    res = list(prj._parse_location_history(fp))
+    assert res == [
+        models.Location(
+            lng=-112.2434441,
+            lat=35.1324213,
+            dt=datetime.datetime(
+                2014, 7, 18, 14, 59, 59, 914000, tzinfo=datetime.timezone.utc
+            ),
+            accuracy=10.0,
+            device_tag=1978796627,
+            source="WIFI",
         ),
     ]
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -81,18 +81,23 @@ def test_parse_likes_json(tmp_path_f: Path) -> None:
 
 
 def test_parse_app_installs(tmp_path_f: Path) -> None:
-    contents = """[{"install": {"doc": {"documentType": "Android Apps", "title": "Discord - Talk, Video Chat & Hang Out with Friends"}, "firstInstallationTime": "2020-05-25T03:11:53.055Z", "deviceAttribute": {"manufacturer": "motorola", "deviceDisplayName": "motorola moto g(7) play"}, "lastUpdateTime": "2020-08-27T02:55:33.259Z"}}]"""
+    contents = """[{"install":{"doc":{"documentType":"Android Apps","title":"ClickUp - Manage Teams & Tasks"},"firstInstallationTime":"2022-03-14T07:06:12.070725Z","deviceAttribute":{"model":"SM-S901E","carrier":"Vodafone","manufacturer":"samsung","deviceDisplayName":"samsung SM-S901E"},"lastUpdateTime":"2024-08-27T22:55:15.184610Z"}}]"""
 
     fp = tmp_path_f / "file"
     fp.write_text(contents)
     res = list(prj._parse_app_installs(fp))
     assert res == [
         models.PlayStoreAppInstall(
-            title="Discord - Talk, Video Chat & Hang Out with Friends",
+            title="ClickUp - Manage Teams \u0026 Tasks",
             dt=datetime.datetime(
-                2020, 5, 25, 3, 11, 53, 55000, tzinfo=datetime.timezone.utc
+                2024, 8, 27, 22, 55, 15, 184610, tzinfo=datetime.timezone.utc
             ),
-            device_name="motorola moto g(7) play",
+            first_installation_dt=datetime.datetime(
+                2022, 3, 14, 7, 6, 12, 70725, tzinfo=datetime.timezone.utc
+            ),
+            device_name="samsung SM-S901E",
+            device_carrier="Vodafone",
+            device_manufacturer="samsung",
         )
     ]
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -170,6 +170,7 @@ def test_chrome_history(tmp_path_f: Path) -> None:
             dt=datetime.datetime(
                 2021, 4, 2, 23, 4, 50, 134513, tzinfo=datetime.timezone.utc
             ),
+            pageTransition="LINK"
         ),
     ]
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -138,7 +138,8 @@ def test_location_new(tmp_path_f: Path) -> None:
             source=None,
         ),
     ]
-    
+
+
 def test_location_2024(tmp_path_f: Path) -> None:
     contents = '{"locations":[{"latitudeE7":351324213,"longitudeE7":-1122434441,"accuracy":10,"activity":[{"activity":[{"type":"UNKNOWN","confidence":65},{"type":"IN_VEHICLE","confidence":27},{"type":"STILL","confidence":6},{"type":"ON_BICYCLE","confidence":2}],"timestamp":"2014-07-18T15:00:04.403Z"}],"source":"WIFI","deviceTag":1978796627,"timestamp":"2014-07-18T14:59:59.914Z"}]}'
     fp = tmp_path_f / "file"
@@ -271,6 +272,7 @@ def test_semantic_location_history(tmp_path_f: Path) -> None:
         ],
     )
 
+
 def test_semantic_location_history_2024(tmp_path_f: Path) -> None:
     data = {
         "timelineObjects": [
@@ -369,9 +371,9 @@ def test_semantic_location_history_2024(tmp_path_f: Path) -> None:
                             "longitudeE7": 1210000500,
                             "accuracyMetres": 163
                         },
-                    "method": "END_OF_ACTIVITY_SEGMENT",
-                    "locationSource": "UNKNOWN",
-                    "timestamp": "2017-12-11T01:40:06Z"
+                        "method": "END_OF_ACTIVITY_SEGMENT",
+                        "locationSource": "UNKNOWN",
+                        "timestamp": "2017-12-11T01:40:06Z"
                     }
                 }
             }

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -269,3 +269,160 @@ def test_semantic_location_history(tmp_path_f: Path) -> None:
             ),
         ],
     )
+
+def test_semantic_location_history_2024(tmp_path_f: Path) -> None:
+    data = {
+        "timelineObjects": [
+            {
+                "placeVisit": {
+                    "location": {
+                        "latitudeE7": 555555555,
+                        "longitudeE7": -1066666666,
+                        "placeId": "JK4E4P",
+                        "address": "address",
+                        "name": "name",
+                        "sourceInfo": {"deviceTag": 987654321},
+                        "locationConfidence": 60.45,
+                    },
+                    "duration": {
+                        "startTimestamp": "2017-12-10T23:29:25.026Z",
+                        "endTimestamp": "2017-12-11T01:20:06.106Z",
+                    },
+                    "placeConfidence": "MEDIUM_CONFIDENCE",
+                    "centerLatE7": 555555555,
+                    "centerLngE7": -1666666666,
+                    "visitConfidence": 65.45,
+                    "otherCandidateLocations": [
+                        {
+                            "latitudeE7": 423984239,
+                            "longitudeE7": -1565656565,
+                            "placeId": "XPRK4E4P",
+                            "address": "address2",
+                            "name": "name2",
+                            "locationConfidence": 24.475897,
+                        },
+                        {
+                            "latitudeE7": 910000000,
+                            "longitudeE7": -1000,
+                            "semanticType": "TYPE_WORK",
+                        },
+                    ],
+                    "editConfirmationStatus": "NOT_CONFIRMED",
+                    "locationConfidence": 55,
+                    "placeVisitType": "SINGLE_PLACE",
+                    "placeVisitImportance": "MAIN",
+                }
+            },
+            {
+                "activitySegment": {
+                    "startLocation": {
+                        "latitudeE7": 555555555,
+                        "longitudeE7": -1066666666
+                    },
+                    "endLocation": {
+                        "latitudeE7": 555555567,
+                        "longitudeE7": -1066666678
+                    },
+                    "duration": {
+                        "startTimestamp": "2017-12-11T01:20:06.106Z",
+                        "endTimestamp": "2017-12-11T01:40:06.106Z"
+                    },
+                    "distance": 13071,
+                    "activityType": "IN_PASSENGER_VEHICLE",
+                    "confidence": "MEDIUM",
+                    "activities": [{
+                        "activityType": "IN_PASSENGER_VEHICLE",
+                        "probability": 85.514968640442
+                    }, {
+                        "activityType": "MOTORCYCLING",
+                        "probability": 8.858836042221917
+                    }, {
+                        "activityType": "WALKING",
+                        "probability": 4.7803567526550035
+                    }],
+                    "waypointPath": {
+                        "waypoints": [{
+                            "latE7": 123456789,
+                            "lngE7": 1210000000
+                        }, {
+                            "latE7": 123456089,
+                            "lngE7": 1210000200
+                        }, {
+                            "latE7": 123456289,
+                            "lngE7": 1210000500
+                        }],
+                        "source": "INFERRED"
+                    },
+                    "simplifiedRawPath": {
+                        "points": [{
+                            "latE7": 123456489,
+                            "lngE7": 1210000240,
+                            "accuracyMeters": 10,
+                            "timestamp": "2017-12-11T01:35:04Z"
+                        }]
+                    },
+                    "editConfirmationStatus": "NOT_CONFIRMED",
+                    "parkingEvent": {
+                        "location": {
+                            "latitudeE7": 123456289,
+                            "longitudeE7": 1210000500,
+                            "accuracyMetres": 163
+                        },
+                    "method": "END_OF_ACTIVITY_SEGMENT",
+                    "locationSource": "UNKNOWN",
+                    "timestamp": "2017-12-11T01:40:06Z"
+                    }
+                }
+            }
+        ]
+    }
+    fp = tmp_path_f / "file"
+    fp.write_text(json.dumps(data))
+    res = list(prj._parse_semantic_location_history(fp))
+    obj = res[0]
+    assert not isinstance(obj, Exception)
+    # remove JSON, compare manually below
+    assert obj == models.PlaceVisit(
+        lat=55.5555555,
+        lng=-106.6666666,
+        centerLat=55.5555555,
+        centerLng=-166.6666666,
+        name="name",
+        address="address",
+        locationConfidence=60.45,
+        placeId="JK4E4P",
+        startTime=datetime.datetime(
+            2017, 12, 10, 23, 29, 25, 26000, tzinfo=datetime.timezone.utc
+        ),
+        endTime=datetime.datetime(
+            2017, 12, 11, 1, 20, 6, 106000, tzinfo=datetime.timezone.utc
+        ),
+        sourceInfoDeviceTag=987654321,
+        placeConfidence="MEDIUM_CONFIDENCE",
+        placeVisitImportance="MAIN",
+        placeVisitType="SINGLE_PLACE",
+        visitConfidence=65.45,
+        editConfirmationStatus="NOT_CONFIRMED",
+        otherCandidateLocations=[
+            models.CandidateLocation(
+                lat=42.3984239,
+                lng=-156.5656565,
+                name="name2",
+                address="address2",
+                locationConfidence=24.475897,
+                placeId="XPRK4E4P",
+                semanticType=None,
+                sourceInfoDeviceTag=None,
+            ),
+            models.CandidateLocation(
+                lat=91.0,
+                lng=-0.0001,
+                name=None,
+                address=None,
+                locationConfidence=None,
+                placeId=None,
+                semanticType='TYPE_WORK',
+                sourceInfoDeviceTag=None,
+            ),
+        ],
+    )

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -122,7 +122,7 @@ def test_location_old(tmp_path_f: Path) -> None:
 
 
 def test_location_new(tmp_path_f: Path) -> None:
-    contents = '{"locations": [{"latitudeE7": 351324213, "longitudeE7": -1122434441, "accuracy": 10, "deviceTag": -80241446968629135069, "deviceDesignation": "PRIMARY", "timestamp": "2017-12-10T23:14:58.030Z"}]}'
+    contents = '{"locations": [{"latitudeE7": 351324213, "longitudeE7": -1122434441, "accuracy": 10, "deviceTag": -8024144696862913506, "deviceDesignation": "PRIMARY", "timestamp": "2017-12-10T23:14:58.030Z"}]}'
     fp = tmp_path_f / "file"
     fp.write_text(contents)
     res = list(prj._parse_location_history(fp))
@@ -134,7 +134,7 @@ def test_location_new(tmp_path_f: Path) -> None:
                 2017, 12, 10, 23, 14, 58, 30000, tzinfo=datetime.timezone.utc
             ),
             accuracy=10.0,
-            deviceTag=-80241446968629135069,
+            deviceTag=-8024144696862913506,
             source=None,
         ),
     ]


### PR DESCRIPTION
Hi, I was reviewing the parser and comparing its output with my own Google Takeout data and I noticed some interesting fields that are not being handled by the parser.  I went ahead and made some changes to include them, but if you think they are not important to track I'd be happy to discuss! 😄 

## Summary of Changes

1. `PlayStoreAppInstall` model
    - Added `deviceName`, `deviceCarrier`, `deviceManufacturer` and `firstInstallationDt` fields
    - Changed `dt` field from the `firstInstallationTime` to the `lastUpdateTime` since this may be a more accurate representation of the installation event. I understand this may have some backward compatibility issues so it might be better to create a new `installationTime` field instead but then the name `dt` can be misleading. I'd love to hear your thoughts on this. 
2. `Location` model
    - Added `deviceTag` and `source` fields
    - This addition introduced a failing test in `test_location_new()` caused by how orjson handles large integers. I've already raised the issue in the orjson repository [here](https://github.com/ijl/orjson/issues/517).
    - Added a new test `test_location_2024` that tests based on the current version of the location data.
3. `ChromeHistory` model
    - Added the `pageTransition` field
4. Added "Chrome/History.json" to the `en` locale HandlerMapping. In my version of the Takeout files it seems to have been renamed from BrowserHistory.json to History.json.
5. Added a new test for the Semantic Location data called `_parse_semantic_location_history_2024` with the current version of the data mocked. I was going to try to include the additional `activitySegment` field, but it seems a bit complex. I'd be happy to discuss how to parse it in a separate issue.